### PR TITLE
Feat: Add Warrant Issuance

### DIFF
--- a/src/db/operations/create.js
+++ b/src/db/operations/create.js
@@ -13,6 +13,7 @@ import StockIssuance from "../objects/transactions/issuance/StockIssuance.js";
 import StockTransfer from "../objects/transactions/transfer/StockTransfer.js";
 import Fairmint from "../objects/Fairmint.js";
 import { save } from "./atomic.ts";
+import WarrantIssuance from "../objects/transactions/issuance/WarrantIssuance.js";
 
 export const createIssuer = (issuerData) => {
     return save(new Issuer(issuerData));
@@ -56,6 +57,10 @@ export const createEquityCompensationIssuance = (issuanceData) => {
 
 export const createConvertibleIssuance = (issuanceData) => {
     return save(new ConvertibleIssuance(issuanceData));
+};
+
+export const createWarrantIssuance = (issuanceData) => {
+    return save(new WarrantIssuance(issuanceData));
 };
 
 export const createStockTransfer = (stockTransferData) => {

--- a/src/fairmint/enums.js
+++ b/src/fairmint/enums.js
@@ -3,4 +3,5 @@ export const SERIES_TYPE = {
     GRANT: "grant",
     SHARES: "shares",
     VERIFICATION: "verification",
+    WARRANT: "warrant",
 };

--- a/src/routes/transactions.js
+++ b/src/routes/transactions.js
@@ -6,6 +6,7 @@ import stockAcceptanceSchema from "../../ocf/schema/objects/transactions/accepta
 import issuerAuthorizedSharesAdjustmentSchema from "../../ocf/schema/objects/transactions/adjustment/IssuerAuthorizedSharesAdjustment.schema.json" assert { type: "json" };
 import stockClassAuthorizedSharesAdjustmentSchema from "../../ocf/schema/objects/transactions/adjustment/StockClassAuthorizedSharesAdjustment.schema.json" assert { type: "json" };
 import stockCancellationSchema from "../../ocf/schema/objects/transactions/cancellation/StockCancellation.schema.json" assert { type: "json" };
+import warrantIssuanceSchema from "../../ocf/schema/objects/transactions/issuance/warrantIssuance.schema.json" assert { type: "json" };
 // import convertibleIssuanceSchema from "../../ocf/schema/objects/transactions/issuance/ConvertibleIssuance.schema.json" assert { type: "json" };
 // import equityCompensationIssuanceSchema from "../../ocf/schema/objects/transactions/issuance/EquityCompensationIssuance.schema.json" assert { type: "json" };
 import stockIssuanceSchema from "../../ocf/schema/objects/transactions/issuance/StockIssuance.schema.json" assert { type: "json" };
@@ -22,7 +23,7 @@ import { convertAndCreateReissuanceStockOnchain } from "../controllers/transacti
 import { convertAndCreateRepurchaseStockOnchain } from "../controllers/transactions/repurchaseController.js";
 import { convertAndCreateRetractionStockOnchain } from "../controllers/transactions/retractionController.js";
 import { convertAndCreateTransferStockOnchain } from "../controllers/transactions/transferController.js";
-import { createConvertibleIssuance, createEquityCompensationIssuance } from "../db/operations/create.js";
+import { createConvertibleIssuance, createEquityCompensationIssuance, createWarrantIssuance } from "../db/operations/create.js";
 
 import {
     readConvertibleIssuanceByCustomId,
@@ -582,6 +583,110 @@ transactions.post("/issuance/convertible-fairmint-reflection", async (req, res) 
         // Note: this will have it's own listener in the future to check with Fairmint Obj and sync with Fairmint accordingly
 
         res.status(200).send({ convertibleIssuance: createdIssuance });
+    } catch (error) {
+        console.error(error);
+        res.status(500).send(`${error}`);
+    }
+});
+
+transactions.post("/issuance/warrant", async (req, res) => {
+    const { issuerId, data } = req.body;
+
+    try {
+        // ensuring issuer exists
+        await readIssuerById(issuerId);
+
+        const incomingWarrantIssuance = {
+            issuer: issuerId, // TEMPORARY: need to change when deployed on chain
+            id: uuid(), // for OCF Validation
+            security_id: uuid(), // for OCF Validation
+            date: new Date().toISOString().slice(0, 10), // for OCF Validation
+            object_type: "TX_WARRANT_ISSUANCE",
+            ...data,
+        };
+
+        console.log("incomingWarrantIssuance", incomingWarrantIssuance);
+        // await validateInputAgainstOCF(incomingWarrantIssuance, warrantIssuanceSchema);
+
+        // save to DB
+        const createdIssuance = await createWarrantIssuance(incomingWarrantIssuance);
+
+        res.status(200).send({ warrantIssuance: createdIssuance });
+    } catch (error) {
+        console.error(error);
+        res.status(500).send(`${error}`);
+    }
+});
+
+transactions.post("/issuance/warrant-fairmint-reflection", async (req, res) => {
+    const { issuerId, data } = req.body;
+    const schema = Joi.object({
+        series_id: Joi.string().uuid().required(),
+        series_name: Joi.string().required(),
+        data: Joi.object().required(),
+        issuerId: Joi.string().uuid().required(),
+    });
+
+    const { error, value: payload } = schema.validate(req.body);
+
+    if (error) {
+        return res.status(400).send({
+            error: getJoiErrorMessage(error),
+        });
+    }
+
+    try {
+        // ensuring issuer exists
+        await readIssuerById(issuerId);
+
+        const incomingWarrantIssuance = {
+            issuer: issuerId, // TEMPORARY: need to change when deployed on chain
+            id: uuid(), // for OCF Validation
+            security_id: uuid(), // for OCF Validation
+            date: new Date().toISOString().slice(0, 10), // for OCF Validation
+            object_type: "TX_WARRANT_ISSUANCE",
+            ...data,
+        };
+
+        console.log("incomingWarrantIssuance", incomingWarrantIssuance);
+        // await validateInputAgainstOCF(incomingWarrantIssuance, warrantIssuanceSchema); //TODO: fix me
+
+        // check if the stakeholder exists
+        const stakeholder = await readStakeholderById(incomingWarrantIssuance.stakeholder_id);
+        if (!stakeholder || !stakeholder._id) {
+            return res.status(400).send({ error: "Stakeholder not found on OCP" });
+        }
+
+        // check stakeholder exists on fairmint
+        await checkStakeholderExistsOnFairmint({
+            stakeholder_id: stakeholder._id,
+            portal_id: issuerId,
+        });
+
+        // save to DB
+        const createdIssuance = await createWarrantIssuance(incomingWarrantIssuance);
+
+        const seriesCreated = await reflectSeries({
+            issuerId,
+            series_id: payload.series_id,
+            series_name: payload.series_name,
+            series_type: SERIES_TYPE.WARRANT,
+        });
+
+        console.log("series reflected response ", seriesCreated);
+
+        const reflectInvestmentResponse = await reflectInvestment({
+            id: incomingWarrantIssuance.id,
+            issuerId,
+            stakeholder_id: stakeholder._id,
+            series_id: payload.series_id,
+            amount: get(incomingWarrantIssuance, "investment_amount.amount", 0),
+        });
+
+        console.log("Reflected Investment Response:", reflectInvestmentResponse);
+        // Note: this will have it's own listener in the future to check with Fairmint Obj and sync with Fairmint accordingly
+
+        res.status(200).send({ warrantIssuance: createdIssuance });
     } catch (error) {
         console.error(error);
         res.status(500).send(`${error}`);

--- a/src/routes/transactions.js
+++ b/src/routes/transactions.js
@@ -6,7 +6,7 @@ import stockAcceptanceSchema from "../../ocf/schema/objects/transactions/accepta
 import issuerAuthorizedSharesAdjustmentSchema from "../../ocf/schema/objects/transactions/adjustment/IssuerAuthorizedSharesAdjustment.schema.json" assert { type: "json" };
 import stockClassAuthorizedSharesAdjustmentSchema from "../../ocf/schema/objects/transactions/adjustment/StockClassAuthorizedSharesAdjustment.schema.json" assert { type: "json" };
 import stockCancellationSchema from "../../ocf/schema/objects/transactions/cancellation/StockCancellation.schema.json" assert { type: "json" };
-import warrantIssuanceSchema from "../../ocf/schema/objects/transactions/issuance/warrantIssuance.schema.json" assert { type: "json" };
+// import warrantIssuanceSchema from "../../ocf/schema/objects/transactions/issuance/warrantIssuance.schema.json" assert { type: "json" };
 // import convertibleIssuanceSchema from "../../ocf/schema/objects/transactions/issuance/ConvertibleIssuance.schema.json" assert { type: "json" };
 // import equityCompensationIssuanceSchema from "../../ocf/schema/objects/transactions/issuance/EquityCompensationIssuance.schema.json" assert { type: "json" };
 import stockIssuanceSchema from "../../ocf/schema/objects/transactions/issuance/StockIssuance.schema.json" assert { type: "json" };


### PR DESCRIPTION
## What?

Add Support for Warrant Issuance Transaction. For now we're storing OCF only *not on chain* We will add the transaction in the future

- [x] Add API endpoint inside transaction without onchain element
- [ ] Add OCF validation for WarrantIssuance ❌
  - Had an issue with OCF (enum file `QuantitySourceType` doesn't exist locally) — skip
- [x] Reflect Series of type warrant
- [x] Check Stakeholder
- [x] Reflect Investment of type warrant
- [x] Show warrants on studio
- [x] Add series warrants type
- [x] [Studio](https://github.com/Fairmint/studio/pull/334)
- [x] API
