### PR TITLE
Fix founders preferred stock captable dashboard mis-calculation

### DIFF
--- a/src/routes/stats/captable.js
+++ b/src/routes/stats/captable.js
@@ -93,10 +93,12 @@ const calculateFounderPreferredSummary = (preferredStockClasses, stockIssuances)
     if (founderIssuances.length === 0) return null;
 
     const outstandingShares = founderIssuances.reduce((sum, issuance) => sum + Number(issuance.quantity), 0);
-
+    
     const founderPreferredClasses = preferredStockClasses.filter(stockClass =>
         founderIssuances.some(issuance => issuance.stock_class_id === stockClass._id)
     );
+
+    if (founderPreferredClasses.length === 0) return null;
 
     const votingPower = founderIssuances.reduce((sum, issuance) => {
         const stockClass = founderPreferredClasses.find(sc => sc._id === issuance.stock_class_id);


### PR DESCRIPTION
## What?

- Fixed miscalculation on founders preferred stock it. We see founders preferred stock when there is **no** preferred stock class exist

<img width="1626" alt="image" src="https://github.com/user-attachments/assets/134d0b10-533f-4e42-b827-e4095b27361d">
