### PR TITLE
Exclude stock-plans shares form totals authorized Shares calculation

### DIFF
--- a/src/routes/stats/captable.js
+++ b/src/routes/stats/captable.js
@@ -418,8 +418,7 @@ const calculateCaptableStats = async (issuerId) => {
         commonSummary.totalSharesAuthorized +
         preferredSummary.totalSharesAuthorized +
         (founderPreferredSummary ? founderPreferredSummary.sharesAuthorized : 0) +
-        (warrantsAndNonPlanAwardsSummary.totalSharesAuthorized || 0) +
-        stockPlansSummary.totalSharesAuthorized;
+        (warrantsAndNonPlanAwardsSummary.totalSharesAuthorized || 0);
 
     const totalFullyDilutedShares =
         commonSummary.rows.reduce((sum, row) => sum + row.fullyDilutedShares, 0) +


### PR DESCRIPTION
## What?

Exclude `stockplan.authorized_shares` from total authorized shares calculation in the OCX Captable calculation