### PR TITLE
Use `JsonRpcProvider` instead `Websocket`

### DIFF
--- a/src/chain-operations/getProvider.js
+++ b/src/chain-operations/getProvider.js
@@ -29,7 +29,8 @@ const getProvider = () => {
         console.log("🔗 | Connected to local network: ", RPC_URL);
     } else {
         console.log("🔗 | Connecting to network: ", RPC_URL);
-        provider = new ethers.WebSocketProvider(RPC_URL);
+        // provider = new ethers.WebSocketProvider(RPC_URL);
+        provider = new ethers.JsonRpcProvider(RPC_URL.replace("ws", "http"));
         console.log("🔗 | Connected to network: ", RPC_URL);
     }
     return provider;


### PR DESCRIPTION
## What?
Transaction receipts are not pulled when call `tx.wait()` blocking the thread.  This is hotfix until we fix the issue
